### PR TITLE
Implement user_edit&delete

### DIFF
--- a/Celebrity/app/controllers/users_controller.rb
+++ b/Celebrity/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  before_action :logged_in_user, only: [:index, :show]
+  before_action :logged_in_user, only: [:index, :show, :edit, :update]
   
   def index
     @users = User.all
@@ -24,12 +24,30 @@ class UsersController < ApplicationController
     end
   end
   
+  def edit
+    @user = User.find(params[:id])
+  end
+  
+  def update
+    @user = User.find(params[:id])
+    if @user.update_attributes(user_params)
+      flash[:success] = 'ユーザ情報を更新しました'
+      redirect_to @user
+    else
+      render 'edit'
+    end
+  end
+  
+  def destroy
+    User.find(params[:id]).update_attribute(:existence, false)
+    flash[:success] = 'ユーザを削除しました'
+    redirect_to users_path
+  end
+  
   private
   
     def user_params
-      params.require(:user).permit(:name, :nickname, :email, :password, :password_confirmation)
+      params.require(:user).permit(:name, :nickname, :email, :password, :password_confirmation, :portfolio_path)
     end
     
-    
-  
 end

--- a/Celebrity/app/models/user.rb
+++ b/Celebrity/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
     before_save { self.email = email.downcase }
+    default_scope -> { order(:created_at) }
     validates :name, presence: true, length: { maximum: 50 }
     validates :nickname, presence: true, length: { maximum: 50 }
     

--- a/Celebrity/app/views/users/edit.html.erb
+++ b/Celebrity/app/views/users/edit.html.erb
@@ -1,0 +1,29 @@
+<h1>ユーザ情報の編集</h1>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= form_for(@user) do |f| %>
+      <%= render 'shared/error_messages' %>
+    
+      <%= f.label :name, "氏名" %>
+      <%= f.text_field :name, class: 'form-control' %>
+
+      <%= f.label :nickname, "ニックネーム" %>
+      <%= f.text_field :nickname, class: 'form-control' %>
+
+      <%= f.label :email %>
+      <%= f.email_field :email, class: 'form-control' %>
+
+      <%= f.label :password, 'パスワード' %>
+      <%= f.password_field :password, class: 'form-control' %>
+
+      <%= f.label :password_confirmation, "パスワード確認" %>
+      <%= f.password_field :password_confirmation, class: 'form-control' %>
+      
+      <%= f.label :portfolio_path, "ポートフォリオURL" %>
+      <%= f.text_field :portfolio_path, class: 'form-control' %>
+
+      <%= f.submit "編集する", class: "btn btn-primary" %>
+    <% end %>
+  </div>
+</div>

--- a/Celebrity/app/views/users/index.html.erb
+++ b/Celebrity/app/views/users/index.html.erb
@@ -3,7 +3,7 @@
 <ul class-"users">
   <% @users.each do |user| %>
     <li>
-      <%= user.nickname %>
+      <%= link_to user.nickname, user %>
       <%= user.email %>
       <%= user.name %>
     </li>

--- a/Celebrity/app/views/users/show.html.erb
+++ b/Celebrity/app/views/users/show.html.erb
@@ -240,3 +240,7 @@
     </tbody>
   <% end %>
 </table>
+
+<%= link_to 'ユーザ編集', edit_user_path(@user) , class: 'btn btn-primary' %>
+<%= link_to 'ユーザ削除', @user, method: :delete, class: 'btn btn-danger',
+    data: { confirm: '本当に削除しますか？' } %>


### PR DESCRIPTION
■実装箇所
・User情報を編集可能なページ(users/:id/edit)
・users/:id/showページに編集/削除ボタン設置（※adminユーザ/ログインユーザの制御は別チケット）
・users#editアクションの実装
・users#updateアクションの実装
・users#destroyアクションの実装