### PR TITLE
ヘッダーメニュー崩れ修正

### DIFF
--- a/Celebrity/app/assets/stylesheets/application.css
+++ b/Celebrity/app/assets/stylesheets/application.css
@@ -62,7 +62,7 @@ body {
 }
 
 .navbar-inverse .navbar-nav > li > a {
-    font-size: 1vw;
+    font-size: 80%;
     line-height: 3em;
     color: #FFFFFF;
 }

--- a/Celebrity/app/assets/stylesheets/custom.css.scss
+++ b/Celebrity/app/assets/stylesheets/custom.css.scss
@@ -82,7 +82,7 @@ li {
 }
 
 .top-phrase{
-  font-size: 1.5vw;
+  font-size: 154%;
   line-height: 3em;
   color: #F8C810;
   padding-left: 20px;


### PR DESCRIPTION
bootstrapの形式は変えず、下記ヘッダー文言のfont-sizeをvmから%へ変更してみたところ、ある程度の縮小（macbook 67%）までは対応可能です。
・セレブエンジニアサロン
・サロンメンバー、マイページ、ログアウト