### PR TITLE
Fix/send user id for delete tag

### DIFF
--- a/Celebrity/app/controllers/users_controller.rb
+++ b/Celebrity/app/controllers/users_controller.rb
@@ -4,7 +4,7 @@ class UsersController < ApplicationController
   before_action :existence_user, only: [:show, :edit, :update]
   before_action :administrator_user, only: :new
   before_action :correct_user_for_edit,
-    only:[:edit, :update, :update_picture, :tag_show, :tag_delete]
+    only:[:edit, :update, :update_picture,:tag_new, :tag_show, :tag_delete]
   
   def index
     @users = User.page(params[:page])
@@ -119,7 +119,6 @@ class UsersController < ApplicationController
     def correct_user_for_edit
       user_id = params[:id]
       user_id ||= params[:user][:id]
-
       @user = User.find(user_id)
       if current_user?(@user)
       else

--- a/Celebrity/app/views/users/show.html.erb
+++ b/Celebrity/app/views/users/show.html.erb
@@ -92,7 +92,7 @@ $('#interest-tags').tagit({
   afterTagAdded: function(event, ui) {
     // FUTURE FIX: onload時にインサートが実行されてしまうため一時回避策
     if(tag_cnt >= <%= @tags_count %>){
-      ajax_insert_new_tag_to_DB(ui.tagLabel);
+      ajax_insert_new_tag_to_DB(ui.tagLabel, <%= @user.id %>);
     }
     tag_cnt += 1;
   },
@@ -105,14 +105,14 @@ $('#interest-tags').tagit({
   },
   afterTagRemoved: function(event, ui) {
     var tag_id = $(ui.tag[0]).find('input:hidden[name="tag_id"]').val();
-    ajax_delete_tag_in_DB(tag_id);
+    ajax_delete_tag_in_DB(tag_id, <%= @user.id %>);
   }
 
 });
 
 $('.tagit-new').css('width','100%');
 
-function ajax_insert_new_tag_to_DB(tagLabel){
+function ajax_insert_new_tag_to_DB(tagLabel, user_id){
   // NOTE:rails のhelperを使用していないため CSRF用のTOKENをヘッダーに含める必要がある。
   $.ajaxPrefilter(function(options, originalOptions, jqXHR) {
     var token;
@@ -123,11 +123,13 @@ function ajax_insert_new_tag_to_DB(tagLabel){
        }
     }
   });
-
+  debugger;
+  var param = 'tag_name=' + tagLabel + '&' + 'id=' + user_id;
+    
   $.ajax({ 
     url: '/tag_new', 
     type: 'POST', 
-    data: ('tag_name=' + tagLabel), 
+    data: param, 
     dataType: 'json' 
   })
   
@@ -138,7 +140,7 @@ function ajax_insert_new_tag_to_DB(tagLabel){
   
 }
 
-function ajax_delete_tag_in_DB(tag_id){
+function ajax_delete_tag_in_DB(tag_id, user_id){
   $.ajaxPrefilter(function(options, originalOptions, jqXHR) {
     var token;
     if (!options.crossDomain) {
@@ -148,11 +150,13 @@ function ajax_delete_tag_in_DB(tag_id){
        }
     }
   });
+  debugger;
+  var param = 'tag_id=' + tag_id + '&' + 'id=' + user_id;
 
   $.ajax({
     url: '/tag_delete', 
     type: 'DELETE', 
-    data: ('tag_id=' + tag_id), 
+    data: param, 
     dataType: 'json' 
   })
   

--- a/Celebrity/app/views/users/show.html.erb
+++ b/Celebrity/app/views/users/show.html.erb
@@ -81,7 +81,7 @@ var tag_cnt = 0;
 
 $('#interest-tags').tagit({
   
-  placeholderText:"興味のある言語やツールのタグをつけよう。最大10個まで",
+  placeholderText:"好きな言語やツールのタグを登録。最大10個",
   fieldName:"user[tag_list]",
   singleField: true,
   removeConfirmation: true,  //バックスペース1回押すとremoveClassが適用。対象タグに色がつく
@@ -123,7 +123,6 @@ function ajax_insert_new_tag_to_DB(tagLabel, user_id){
        }
     }
   });
-  debugger;
   var param = 'tag_name=' + tagLabel + '&' + 'id=' + user_id;
     
   $.ajax({ 
@@ -150,7 +149,6 @@ function ajax_delete_tag_in_DB(tag_id, user_id){
        }
     }
   });
-  debugger;
   var param = 'tag_id=' + tag_id + '&' + 'id=' + user_id;
 
   $.ajax({


### PR DESCRIPTION
アドミンとユーザーがタグを削除不可だったので、修正しました。
アドミンが一般ユーザーのタグを新規登録/削除不可にしました。

原因：下記のロジックを通すためにparams[:id]を通すのを失念していたためです。
    def correct_user_for_edit
      user_id = params[:id]
      user_id ||= params[:user][:id]
      @user = User.find(user_id)
      if current_user?(@user)
      else
        flash[:danger] = "アドミンは一般ユーザーの個別情報を編集できません"
        redirect_to root_url 
      end
    end

