### PR TITLE
Progateの完了予定日アラートチェックが古いカラムを参照していたためいったんコメントアウト

### DIFF
--- a/Celebrity/app/views/top/index.html.erb
+++ b/Celebrity/app/views/top/index.html.erb
@@ -8,10 +8,12 @@
       
     <% day = Date.today %>
     <!--ここにアラート入れる-->
+    <!--完了予定日の参照変更中のため一旦コメントアウト
     <h4 style="color:red;"><%= @alert_messages_html + "→【Progate:HTML&CSSコース】" if @alert_messages_html.present? %></h4>
     <h4 style="color:red;"><%= @alert_messages_javascript + "→【Progate:javascriptコース】" if @alert_messages_javascript.present? %></h4>
     <h4 style="color:red;"><%= @alert_messages_ruby + "→【Progate:rubyコース】" if @alert_messages_ruby.present? %></h4>
     <h4 style="color:red;"><%= @alert_messages_rubyonrails + "→【Progate:ruby on railsコース】" if @alert_messages_rubyonrails.present? %></h4>
+    -->
     <h4 style="color:red;"><%= @alert_messages_railstutorial + "→【railsチュートリアル】" if @alert_messages_railstutorial.present? %></h4>
     <h4 style="color:red;"><%= @alert_message_mv + "まだ見終わっていない動画があります" if @alert_message_mv.present? %></h4>
     


### PR DESCRIPTION
『Progate』の完了予定日で表示されるアラートを一旦表示されないようにコメントアウトいたしました。